### PR TITLE
Bump Setup Typst to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,9 @@ jobs:
         with:
           crate: tytanic
           git: https://github.com/tingerrr/tytanic.git
-      - uses: yusancky/setup-typst@v2
-        id: setup-typst
+      - uses: typst-community/setup-typst@v4
         with:
-          version: 'v0.13.1'
+          typst-version: 'v0.13.1'
       - run: |
           mkdir -p ~/.local/share/typst/packages/preview/cetz
           git clone --depth 1 --branch v0.3.4 https://github.com/cetz-package/cetz.git ~/.local/share/typst/packages/preview/cetz/0.3.4


### PR DESCRIPTION
Bump [`typst-community/setup-typst`](https://github.com/typst-community/setup-typst) to v4

> [!IMPORTANT] 
> The action `yusancky/setup-typst` has officially been migrated to repository `typst-community/setup-typst`. See [announcement](https://github.com/yusancky/setup-typst/blob/main/announcement.md) for more information.

----

> [!NOTE]
> I should also tell you that it may be helpful to use [Packages cache of Setup Typst](https://github.com/typst-community/setup-typst?tab=readme-ov-file#packages-cache) to download cetz to `~/.local/share/typst/packages/preview/cetz` instead of the following code below in `ci.yml`.
> ```yml
> - run: |
>     mkdir -p ~/.local/share/typst/packages/preview/cetz
>     git clone --depth 1 --branch v0.3.4 https://github.com/cetz-package/cetz.git ~/.local/share/typst/packages/preview/cetz/0.3.4
> ```